### PR TITLE
Fix code bug in parse config file.

### DIFF
--- a/support.c
+++ b/support.c
@@ -385,8 +385,6 @@ int parse_config_file(const char *file) {
     FILE *config_file;
     char line_buffer[256];
     int ctrl = 0;
-    char current_secret[256];
-    memset(current_secret, 0, sizeof(current_secret));
 
     /* otherwise the list will grow with each call */
     reset_config_variables();
@@ -397,6 +395,8 @@ int parse_config_file(const char *file) {
         return 0;
     }
 
+    char current_secret[256];
+    memset(current_secret, 0, sizeof(current_secret));
     while (fgets(line_buffer, sizeof line_buffer, config_file)) {
         if(*line_buffer == '#' || isspace(*line_buffer))
             continue; /* skip comments and blank line. */

--- a/support.c
+++ b/support.c
@@ -269,7 +269,7 @@ int reset_config_variables () {
 int _pam_parse_arg (const char *arg, char* current_secret, uint current_secret_buffer_size) {
     int ctrl = 0;
 
-    if (!strcmp (arg, "debug") || !strcmp (arg, "debug=on")) { /* all */
+    if (!strcmp (arg, "debug")) { /* all */
         ctrl |= PAM_TAC_DEBUG;
     } else if (!strcmp (arg, "use_first_pass")) {
         ctrl |= PAM_TAC_USE_FIRST_PASS;


### PR DESCRIPTION
This PR is a draft PR to help review patch file change in https://github.com/Azure/sonic-buildimage/pull/8715
The code change in this PR include:
1. Because tacplus_nss.conf format issue, need update support.c to parse it correctly:
            Support debug=on setting.
            Support put server address and secret in same row.
2. Fix the parse_config_file method not reset server list before parse config file issue.